### PR TITLE
Support for sonar behind a proxy server

### DIFF
--- a/examples/sonar-scan-example/README.md
+++ b/examples/sonar-scan-example/README.md
@@ -11,14 +11,16 @@ should be checked using a policy.
 ## Environment variables
 - `SONAR_TOKEN` - The sonar server token.
 - `SONAR_TYPE` - Should be Either SAAS or SELFHOSTED, defaulting to SAAS.
-- `SONAR_HOST` - The sonar server host name, for example sonar.myconpany.org. required for SELFHOSTED type, if not provided for SAAS type sonarcloud.io is used as default.
+- `SONAR_HOST_URL` - The sonar server host name, for example sonar.myconpany.org. required for SELFHOSTED type, if not provided for SAAS type sonarcloud.io is used as default.
+- `SONAR_PROXY_URL` - The proxy server URL, in the format of http://your-proxy-server:port. or https://username:password@your-proxy-server:port
 
 ## Arguments
 `--reportTaskFile=<path>` - The path to the sonar report task file.
-
 `--FailOnAnalysisFailure` - Fail with exit code 1 if the sonar analysis failed in sonar quality gate.
-
-
+`--WaitTime=<seconds>` - between sonar analysis results checks>
+`--MaxRetries=<number>` - The maximum number of retries to check the sonar analysis results.
+`--UseProxy` - Use a proxy server URL, requires PROXY_URL environment variable to be set.
+ 
 ## The example is based on the following steps:
 1. set sonar token as an environment variable
 2. call sonar scan

--- a/examples/sonar-scan-example/main.go
+++ b/examples/sonar-scan-example/main.go
@@ -99,6 +99,7 @@ func main() {
     failOnAnalysisFailure := false
     maxRetries := 1
     waitTime := 5
+    proxyURL := ""
     if len(os.Args) > 0 {
         // loop over all args
         for i, arg := range os.Args {
@@ -123,6 +124,13 @@ func main() {
                     logger.Println("Invalid wait time argument:",waitTimeStr , "error:" ,err)
                     os.Exit(1)
                 }
+            } else if strings.HasPrefix(arg, "--UseProxy") {
+                proxyURL = os.Getenv("SONAR_PROXY_URL")
+
+                if proxyURL == "" {
+                    logger.Println("SONAR_PROXY_URL not found, set SONAR_PROXY_URL variable when using --UseProxy argument")
+                    os.Exit(1)
+                }
             }
         }
         logger.Println("reportTaskFile:", reportTaskFile)
@@ -132,7 +140,7 @@ func main() {
      }
     response := SonarResponse{}
     defaultSonarHost := "sonarcloud.io"
-    sonarHost := os.Getenv("SONAR_HOST")
+    sonarHost := os.Getenv("SONAR_HOST_URL")
 
     if sonar_type == "SAAS" {
         if sonarHost == "" {
@@ -142,12 +150,12 @@ func main() {
 
     }else if sonar_type == "SELFHOSTED" {
         if sonarHost == "" {
-            logger.Println("Sonar host not found, set SONAR_HOST variable")
+            logger.Println("Sonar host not found, set SONAR_HOST_URL variable")
             os.Exit(1)
         }
         logger.Println("Running sonar analysis extraction for " , sonar_type,  " server", sonarHost)
     }
-    response, err = runReport(ctx, logger, sonarHost, sonar_token, reportTaskFile, failOnAnalysisFailure,  maxRetries, waitTime)
+    response, err = runReport(ctx, logger, sonarHost, proxyURL, sonar_token, reportTaskFile, failOnAnalysisFailure,  maxRetries, waitTime)
 
     if err != nil {
         logger.Println("Error in generating report predicate:", err)


### PR DESCRIPTION
added support for accessing sonar that is behind a proxy server
added environment vars: 
SONAR_PROXY_URL

renamed environment variable: SONAR_HOST to SONAR_HOST_URL to align it with sonar environment variables

added --UseProxy argument to allow customers direct sonar calls through the proxy they have configured on the SONAR_PROXY_URL environment variable